### PR TITLE
Improving long_description display

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -90,7 +90,16 @@
         </section>
 
         <section>
-          <%= simple_format @book.long_description, tags: ['em'] %>
+          <%=
+          simple_format(
+            @book.long_description.gsub(
+              /\r\n\r\n/, "\r\n"
+            ).gsub(
+              /\r\n/, "\r\n\r\n"
+            ),
+            tags: ['em']
+          )
+          %>
         </section>
       </article>
 


### PR DESCRIPTION
Removing single newlines and replacing them with double newlines. This removes <br> tags and makes the content generally look better.