### PR TITLE
Changing the books-per-category count into a lazy value

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: bundle exec rake db:migrate && rake bt:maintain_collation
+release: bundle exec rake db:migrate && rake bt:maintain_collation && rake bt:update_category_counters
 web: bundle exec puma -C config/puma.rb

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,16 +29,10 @@ class Category < ApplicationRecord
     name
   end
 
-  def book_count
-    book_count_collection.count
-  end
-
-  def book_count_print
-    book_count_collection.where(for_print: true).count
-  end
-
-  def book_count_web
-    book_count_collection.where(for_print: true).count
+  def update_counts
+    self.book_count       = book_count_collection.count
+    self.book_count_web   = book_count_collection.where(for_web: true).count
+    self.book_count_print = book_count_collection.where(for_print: true).count
   end
 
   private

--- a/db/migrate/20220822190455_add_book_count_to_categories.rb
+++ b/db/migrate/20220822190455_add_book_count_to_categories.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddBookCountToCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :categories, :book_count, :integer
+    add_column :categories, :book_count_web, :integer
+    add_column :categories, :book_count_print, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_125556) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_22_190455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -220,6 +220,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_125556) do
     t.datetime "updated_at", null: false
     t.integer "group"
     t.string "name"
+    t.integer "book_count"
+    t.integer "book_count_web"
+    t.integer "book_count_print"
     t.index ["slug"], name: "index_categories_on_slug", unique: true
     t.index ["source_id"], name: "index_categories_on_source_id", unique: true
   end

--- a/lib/tasks/bokatidindi.rake
+++ b/lib/tasks/bokatidindi.rake
@@ -188,4 +188,12 @@ namespace :bt do
       puts [b.publisher.name, b.id, b.title].to_csv
     end
   end
+
+  desc 'Update book counts per category'
+  task update_category_counters: :environment do
+    Category.all.each do |c|
+      c.update_counts
+      c.save
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -156,6 +156,12 @@ RSpec.configure do |config|
       )
       book.attach_cover_image_from_string(image_contents)
     end
+
+    # This emulates the bt:update_category_counters rake task.
+    Category.all.each do |c|
+      c.update_counts
+      c.save
+    end
   end
 
   config.after(:suite) do


### PR DESCRIPTION
- This should reduce the number of heavy queries run on every page load
- A rake task is used for updating the number of books per category