### PR TITLE
Changing description handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Metrics/BlockLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 310
+  Max: 320
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:

--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -266,10 +266,10 @@ ActiveAdmin.register Book do
 
     f.inputs 'Lýsing' do
       f.input :description,
-              as: :string,
+              as: :text,
               required: true,
               input_html: {
-                rows: 2,
+                rows: 5,
                 autocomplete: 'off',
                 maxlength: Book::DESCRIPTION_MAX_LENGTH
               },
@@ -279,7 +279,7 @@ ActiveAdmin.register Book do
       f.input :long_description,
               as: :text,
               input_html: {
-                rows: 10,
+                rows: 30,
                 autocomplete: 'off',
                 maxlength: Book::LONG_DESCRIPTION_MAX_LENGTH
               },

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -26,6 +26,7 @@ form.formtastic {
   input.language { width: 16em; }
   input.datepicker { width: 8em; }
   a.has_many_remove { margin-left: 20%; margin-top: 1em; }
+  textarea#book_description, textarea#book_long_description { max-width: 80em; }
 }
 
 .index_as_table {

--- a/app/controllers/xml_feeds_controller.rb
+++ b/app/controllers/xml_feeds_controller.rb
@@ -3,6 +3,7 @@
 class XmlFeedsController < ApplicationController
   include ActionView::Helpers::AssetUrlHelper
   include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::TextHelper
 
   def edition_for_print
     edition = if params[:id] == 'current'
@@ -48,7 +49,7 @@ class XmlFeedsController < ApplicationController
       xml.title book[:title_hypenated]
       xml.post_title book[:post_title] unless book[:post_title].empty?
       xml.description do
-        xml << sanitize(book.short_description.squish, tags: ['em'])
+        xml << book.description_for_print
       end
       if book.cover_image?
         # Two paths for the front cover are provided. The full URL for

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -23,7 +23,7 @@ class Book < ApplicationRecord
   CATEGORIES_SEARCH_COLUMNS = %i[origin_name slug].freeze
 
   TITLE_MAX_LENGTH            = 110
-  DESCRIPTION_MAX_LENGTH      = 380
+  DESCRIPTION_MAX_LENGTH      = 350
   LONG_DESCRIPTION_MAX_LENGTH = 3000
 
   include ActionView::Helpers::UrlHelper
@@ -61,7 +61,7 @@ class Book < ApplicationRecord
 
   paginates_per 18
 
-  before_validation :sanitize_title
+  before_validation :sanitize_title, :sanitize_description
   before_create :set_title_hypenation, :set_slug
   before_update :set_title_hypenation
 
@@ -129,6 +129,18 @@ class Book < ApplicationRecord
 
   def cover_image?
     cover_image.attached?
+  end
+
+  def description_for_print
+    description.gsub(/\r\n\r\n/, "\r\n")
+  end
+
+  def sanitize_description
+    self.description = description.gsub(/[\r\n]+/, "\r\n\r\n")
+                                  .strip&.upcase_first
+
+    self.long_description = long_description.gsub(/[\r\n]+/, "\r\n\r\n")
+                                            .strip&.upcase_first
   end
 
   def sanitize_title

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -85,21 +85,12 @@
         aria-label="Lýsing"
         class="book-description mb-5 bt-5 overflow-hidden"
       >
-        <section>
+        <section id="book_description">
           <%= simple_format @book.description, tags: ['em'] %>
         </section>
 
-        <section>
-          <%=
-          simple_format(
-            @book.long_description.gsub(
-              /\r\n\r\n/, "\r\n"
-            ).gsub(
-              /\r\n/, "\r\n\r\n"
-            ),
-            tags: ['em']
-          )
-          %>
+        <section id="book_long_description">
+          <%=  simple_format @book.long_description, tags: ['em'] %>
         </section>
       </article>
 

--- a/lib/tasks/bokatidindi.rake
+++ b/lib/tasks/bokatidindi.rake
@@ -205,4 +205,12 @@ namespace :bt do
       puts "✅ #{b.slug}" if b.attach_print_image_variant
     end
   end
+
+  desc 'Run .sanitize_description on all books'
+  task sanitize_book_descriptions: :environment do
+    Book.all.each do |b|
+      b.sanitize_description
+      b.save
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -68,4 +68,20 @@ RSpec.describe Book, type: :model do
       expect(book.slug).to eq(original_slug)
     end
   end
+
+  context 'sanitation for description' do
+    it 'is applied on creation' do
+      description = "Lorem ipsum.\r\nDolor sit amet.\r\n\r\n\r\nEt dor im dium."
+      long_description = "#{description}\r\n\r\n\r\n" * 6
+
+      book = create(:book, description:, long_description:)
+
+      expect(book.description).to eq(
+        "Lorem ipsum.\r\n\r\nDolor sit amet.\r\n\r\nEt dor im dium."
+      )
+      expect(book.description_for_print).to eq(
+        "Lorem ipsum.\r\nDolor sit amet.\r\nEt dor im dium."
+      )
+    end
+  end
 end


### PR DESCRIPTION
- Any abritrary number of return-newline is now converted into a double return-newline on update/creation
- Print feed uses a single newline between paragraphs
- Adding rake task to update descriptions