### PR TITLE
Adding rake task to reset book edition categories

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -446,11 +446,11 @@ class Book < ApplicationRecord
     cover_variant.processed.url
   end
 
-  private
-
   def reset_book_edition_categories
     book_editions.active.each(&:reset_book_edition_categories)
   end
+
+  private
 
   def attach_cover_image_variants
     attach_cover_image_variant('webp')

--- a/lib/tasks/bokatidindi.rake
+++ b/lib/tasks/bokatidindi.rake
@@ -220,4 +220,9 @@ namespace :bt do
                    .where(binding_type: { name: 'Endurútgáfa' })
                    .destroy_all
   end
+
+  desc 'Reset book_edition_categories for all books'
+  task reset_book_edition_categories: :environment do
+    Book.all.each(&:reset_book_edition_categories)
+  end
 end


### PR DESCRIPTION
This should remove the issue whereas books that were only supposed to appear in the print edition were appearing in the web edition.

Note: Remember to take a backup before this is run!