### PR TITLE
Introducing sample pages

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -188,6 +188,12 @@ main {
     margin-top: 3rem;
   }
 
+  .preview-images {
+    img {
+      width: 100%;
+    }
+  }
+
   #book_audio_sample {
     h3 {
       font-family: $montserrat;

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -55,15 +55,38 @@
 
         <figure class="figure">
           <% if @book.cover_image.attached? %>
-          <img
-            src="<%= @book.cover_image_url %>"
-            height="<%= @book.cover_image.metadata[:height] %>"
-            width="<%= @book.cover_image.metadata[:width] %>"
-            srcset="<%= @book.cover_img_srcset(@image_format) %>"
-            class="img-fluid"
+          <a
+            data-fancybox="samples"
+            href="<%= @book.cover_image_url %>"
           >
+            <img
+              src="<%= @book.cover_image_url %>"
+              height="<%= @book.cover_image.metadata[:height] %>"
+              width="<%= @book.cover_image.metadata[:width] %>"
+              srcset="<%= @book.cover_img_srcset(@image_format) %>"
+              class="img-fluid"
+            >
+          </a>
           <% end %>
         </figure>
+
+        <div
+          class="preview-images d-none d-md-flex align-self-end row"
+          aria-label="Sýnishorn úr bók"
+        >
+          <% @book.sample_pages.each_with_index do |sp,i| %>
+          <a
+            class="preview-image-link col-md-6 col-xl-3 col-xxl-2 mb-2"
+            data-fancybox="samples"
+            href="<%= @book.sample_page_variant_url(i, 1600, @image_format) %>"
+          >
+            <img
+              src="<%= @book.sample_page_variant_url(i, 150, @image_format) %>"
+              class="sample_image"
+            >
+          </a>
+          <% end %>
+        </div>
 
         <div class="d-none d-md-block">
           <%= render 'books/meta', book: @book %>
@@ -127,3 +150,22 @@
 </div>
 
 </main>
+
+<script>
+Fancybox.defaults.l10n = {
+  CLOSE: "Loka",
+  NEXT: "Næsta mynd",
+  PREV: "Fyrri mynd",
+  MODAL: "Hægt er að loka þessum glugga með ESC-takkanum á lyklaborðinu",
+  ERROR: "Eitthvað kom upp, reyndu aftur síðar",
+  IMAGE_ERROR: "Myndin fannst ekki",
+  ELEMENT_NOT_FOUND: "HTML-Element fannst ekki",
+  AJAX_NOT_FOUND: "Error Loading AJAX : Not Found",
+  AJAX_FORBIDDEN: "Error Loading AJAX : Forbidden",
+  IFRAME_ERROR: "Error Loading Page",
+  TOGGLE_ZOOM: "Súma",
+  TOGGLE_SLIDESHOW: "Sjálfvirk glærusýning",
+  TOGGLE_FULLSCREEN: "Fullur skjár",
+  TOGGLE_THUMBS: "Smámyndir"
+};
+</script>

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -15,6 +15,9 @@
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.5/dist/umd/popper.min.js" integrity="sha384-Xe+8cL9oJa6tN/veChSP7q+mnSPaj5Bcu9mPX5F5xIGE0DVittaqT5lorf0EI7Vk" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.min.js" integrity="sha384-kjU+l4N0Yf4ZOJErLsIcvOU2qSb74wXpOhqTvwVx3OElZRweTnQ6d31fXEoRD1Jy" crossorigin="anonymous"></script>
 
+<%= tag 'link', rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.css' %>
+<%= tag 'script', src: 'https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.umd.js' %>
+
 <%= stylesheet_link_tag 'application', media: 'all' %>
 <%= javascript_include_tag 'application.js' %>
 


### PR DESCRIPTION
Uses Fancybox to display a zoomed-in modal of cover page and sampples.

Samples are hidden in smaller viewports.

We're using Bootstrap columns here instead of the scrollable row from the original UX draft, so consider this an interim solution.