### PR TITLE
Handling closing and print days for BookEditions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,6 +72,7 @@ Metrics/MethodLength:
   Max: 80
   Exclude:
     - 'db/migrate/*'
+    - 'app/admin/books.rb'
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -446,7 +446,7 @@ class Book < ApplicationRecord
   end
 
   def reset_book_edition_categories
-    book_editions.active.each(&:reset_book_edition_categories)
+    book_editions.active.each(&:update_book_edition_categories)
   end
 
   private

--- a/app/models/book_edition.rb
+++ b/app/models/book_edition.rb
@@ -28,22 +28,92 @@ class BookEdition < ApplicationRecord
     ).order(id: :desc).limit(1)
   }
 
-  after_create :set_book_edition_categories
-  after_update :reset_book_edition_categories
+  after_create :create_book_edition_categories
 
-  def reset_book_edition_categories
-    book_edition_categories.destroy_all
-    set_book_edition_categories
+  def update_book_edition_categories(force: true)
+    book_categories = book.book_categories
+    category_ids = book_categories.pluck(:category_id)
+
+    book_edition_categories.where.not(
+      category_id: category_ids
+    ).destroy_all
+
+    if edition.active? || force == true
+      # Delete the BookEditionCategory records if the current edition is
+      # open for both print and web registrations and re-enter them into the
+      # database
+      update_book_edition_categories_before_print_registration_ends
+    elsif edition.print_registration_over?
+      # Only amend records to set for_web to false if for_print equals true
+      # instead of deleting them.
+      update_book_edition_categories_after_print_registration
+    end
+
+    book_edition_categories.where(for_web: false, for_print: false).destroy_all
+
+    book_edition_categories
   end
 
-  def set_book_edition_categories
+  def create_book_edition_categories
     book.book_categories.each do |bc|
+      next unless (Edition.current.ids).include?(edition.id)
+
+      for_print = if bc.for_print == true
+                    if edition.print_registration_over?
+                      false
+                    else
+                      bc.for_print
+                    end
+                  else
+                    bc.for_print
+                  end
+
       BookEditionCategory.create(
         book_edition_id: id,
         category_id: bc.category_id,
         for_web: bc.for_web,
-        for_print: bc.for_print
+        for_print:
       )
+    end
+  end
+
+  private
+
+  def update_book_edition_categories_before_print_registration_ends
+    book.book_categories.each do |bc|
+      current_book_edition_category = book_edition_categories.find_by(
+        book_edition_id: id,
+        category: bc.category
+      )
+      if current_book_edition_category.instance_of?(BookEditionCategory)
+        current_book_edition_category.for_web = bc.for_web
+        current_book_edition_category.for_print = bc.for_print
+        current_book_edition_category.save
+      else
+        BookEditionCategory.create(
+          book_edition_id: id, category_id: bc.category_id,
+          for_web: bc.for_web, for_print: bc.for_print
+        )
+      end
+    end
+  end
+
+  def update_book_edition_categories_after_print_registration
+    book.book_categories.each do |bc|
+      current_book_edition_category = book_edition_categories.find_by(
+        book_edition_id: id,
+        category_id: bc.category_id
+      )
+      if current_book_edition_category.instance_of?(BookEditionCategory)
+        current_book_edition_category.for_web = bc.for_web
+
+        current_book_edition_category.save
+      elsif bc.for_web == true
+        BookEditionCategory.create(
+          book_edition_id: id, category_id: bc.category_id,
+          for_web: true, for_print: false
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- The period between closing and printing are locked for new BookEditionCategory registrations from publishers
- Admins will be able to update BookEditionCategory records for current editions