### PR TITLE
Adding relation between editions and publishers and authors

### DIFF
--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class IndexesController < ApplicationController
+  def publishers
+    edition = Edition.current.first
+    @publishers_by_first_initial = edition.publishers_by_first_initial
+  end
+
+  def authors
+    edition = Edition.current.first
+    @authors_by_first_initial = edition.authors_by_first_initial
+  end
+end

--- a/app/helpers/indexes_helper.rb
+++ b/app/helpers/indexes_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module IndexesHelper
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -42,6 +42,50 @@ class Edition < ApplicationRecord
   has_many :book_editions, dependent: :destroy
   has_many :books, through: :book_editions
 
+  def publisher_ids
+    books.distinct(:publisher_id).pluck(:publisher_id)
+  end
+
+  def publishers
+    Publisher.where(id: publisher_ids).order(:name)
+  end
+
+  def publishers_by_first_initial
+    initials = {}
+    publishers.each do |p|
+      initial = p.name.first
+      initials[initial] = [] unless initials.key?(initial)
+      initials[initial] << p
+    end
+    initials
+  end
+
+  def author_ids
+    BookAuthor.joins(
+      book: [:book_editions]
+    ).where(
+      book_editions: { edition_id: id }
+    ).distinct(
+      :author_id
+    ).pluck(
+      :author_id
+    )
+  end
+
+  def authors
+    Author.where(id: author_ids).order(:order_by_name)
+  end
+
+  def authors_by_first_initial
+    initials = {}
+    authors.each do |a|
+      initial = a.order_by_name.first
+      initials[initial] = [] unless initials.key?(initial)
+      initials[initial] << a
+    end
+    initials
+  end
+
   def active?
     Edition.active.ids.include?(id)
   end

--- a/app/views/indexes/authors.html.erb
+++ b/app/views/indexes/authors.html.erb
@@ -1,0 +1,28 @@
+<main role="main">
+
+  <div class="container-fluid">
+
+    <div class="row mx-2">
+
+      <div class="col-12">
+
+      <h2>Höfundar</h2>
+
+      </div>
+
+      <% @authors_by_first_initial.each_key do |initial| %>
+      <div class="col-12 col-lg-3">
+        <h3><%= initial %></h3>
+        <ul>
+          <% @authors_by_first_initial[initial].each do |a| %>
+          <li><%= link_to a.name, author_path(a.slug) %></li>
+          <% end %>
+        </ul>
+      </div>
+      <% end %>
+
+    </div>
+
+  </div>
+
+</main>

--- a/app/views/indexes/publishers.html.erb
+++ b/app/views/indexes/publishers.html.erb
@@ -1,0 +1,28 @@
+<main role="main">
+
+  <div class="container-fluid">
+
+    <div class="row mx-2">
+
+      <div class="col-12">
+
+        <h2>Útgefendur</h2>
+
+      </div>
+
+      <% @publishers_by_first_initial.each_key do |initial| %>
+      <div class="col-12 col-lg-3">
+        <h3><%= initial %></h3>
+        <ul>
+          <% @publishers_by_first_initial[initial].each do |p| %>
+          <li><%= link_to p.name, publisher_path(p.slug) %></li>
+          <% end %>
+        </ul>
+      </div>
+      <% end %>
+
+    </div>
+
+  </div>
+
+</main>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav aria-label="Aðalvalmynd" class="navbar order-4 d-none d-sm-block col-12 navbar-expand-md mt-3">
-  <ul class="navbar-nav">
+  <ul class="navbar-nav float-left">
     <% Category.groups.each do |category_group| %>
     <li class="nav-item dropdown">
       <a
@@ -22,6 +22,24 @@
       </ul>
     </li>
     <% end %>
+  </ul>
+  <ul class="navbar-nav float-right">
+    <li class="nav-item">
+      <a
+        href="/hofundar"
+        class="nav-link"
+      >
+        Höfundaskrá
+      </a>
+    </li>
+    <li class="nav-item">
+      <a
+        href="/utgefendur"
+        class="nav-link"
+      >
+        Útgefendaskrá
+      </a>
+    </li>
   </ul>
 </nav>
 
@@ -48,5 +66,21 @@
       </ul>
     </li>
     <% end %>
+  </ul>
+  <ul class="nav-list list-unstyled mx-5">
+    <li class="">
+      <a
+        href="/hofundar"
+      >
+        Höfundaskrá
+      </a>
+    </li>
+    <li class="">
+      <a
+        href="/utgefendur"
+      >
+        Útgefendaskrá
+      </a>
+    </li>
   </ul>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,7 @@ Rails.application.routes.draw do
 
   get 'xml_feeds/editions_for_print/:id', to: 'xml_feeds#edition_for_print'
   get 'xml_feeds/editions_for_print/current', to: 'xml_feeds#edition_for_print'
+
+  get 'utgefendur', to: 'indexes#publishers'
+  get 'hofundar', to: 'indexes#authors'
 end

--- a/spec/requests/indexes_spec.rb
+++ b/spec/requests/indexes_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Indexes', type: :request do
+  describe 'controller' do
+    it 'renders the authors index template using valid HTML' do
+      get '/hofundar'
+      html_doc = Nokogiri::HTML5::Document.parse(response.body)
+      expect(html_doc.errors).to be_empty
+    end
+    it 'renders the publishers index template using valid HTML' do
+      get '/utgefendur'
+      html_doc = Nokogiri::HTML5::Document.parse(response.body)
+      expect(html_doc.errors).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Adding methods to the Edition model to retrieve its related publishers and authors, or their IDs.

This also adds a method to order authors and publishers by their first initial, as per the original UX draft.

This adds draft index views for publishers and authors and links to those indexes in the navbar.