### PR TITLE
Lazy loading image variants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/BlockLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 400
+  Max: 420
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:

--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -161,6 +161,8 @@ ActiveAdmin.register Book do
 
         Category.update_all_counts
 
+        SetImageVariantsJob.perform_later @resource
+
         return redirect_to(
           admin_books_path,
           notice: "Bókin #{@resource.title} hefur verið uppfærð."
@@ -247,6 +249,8 @@ ActiveAdmin.register Book do
         sample_pages_files.each do |spf|
           @resource.attach_sample_page_from_string(spf[:contents])
         end
+
+        SetImageVariantsJob.perform_later @resource
 
         Category.update_all_counts
 

--- a/app/jobs/set_image_variants_job.rb
+++ b/app/jobs/set_image_variants_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SetImageVariantsJob < ApplicationJob
+  queue_as :default
+
+  def perform(book)
+    book.update_srcsets
+    book.save
+  end
+end

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -20,7 +20,7 @@
               src="<%= book.cover_image_url %>"
               height="<%= book.cover_image.metadata[:height] %>"
               width="<%= book.cover_image.metadata[:width] %>"
-              srcset="<%= book.cover_img_srcset(@image_format) %>"
+              srcset="<%= book.cover_image_srcsets[@image_format] %>"
               class="img-fluid"
               loading="lazy"
             >

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -108,7 +108,7 @@
               src="<%= @book.cover_image_url %>"
               height="<%= @book.cover_image.metadata[:height] %>"
               width="<%= @book.cover_image.metadata[:width] %>"
-              srcset="<%= @book.cover_img_srcset(@image_format) %>"
+              srcset="<%= @book.cover_image_srcsets[@image_format] %>"
               class="img-fluid"
               alt="Forsíða bókarinnar"
             >
@@ -124,12 +124,13 @@
           <a
             class="preview-image-link col-6 col-xl-3 col-xxl-2 mb-2"
             data-fancybox="samples"
-            href="<%= @book.sample_page_variant_url(i, 1600, @image_format) %>"
+            href="<%= @book.sample_page_url(i, @image_format) %>"
             title="Skoða sýnidæmi"
           >
             <img
-              src="<%= @book.sample_page_variant_url(i, 150, @image_format) %>"
               class="sample_image"
+              src="<%= @book.sample_page_url(i, @image_format) %>"
+              srcset="<%= @book.sample_pages_srcsets[@image_format][i].join(' ') %>"
               width="<%= @book.sample_pages[i].metadata[:width]/8 %>"
               height="<%= @book.sample_pages[i].metadata[:height]/8 %>"
               alt="Sýnidæmi <%= i + 1 %>"

--- a/db/migrate/20221022013609_add_srcsets_to_books.rb
+++ b/db/migrate/20221022013609_add_srcsets_to_books.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddSrcsetsToBooks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :books, :cover_image_srcsets, :json, default: {
+      'webp': [], 'jpg': []
+    }
+    add_column :books, :sample_pages_srcsets, :json, default: {
+      'webp': [], 'jpg': []
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_135416) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_22_013609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_prewarm"
   enable_extension "pg_stat_statements"
@@ -213,6 +213,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_135416) do
     t.string "title_hypenated"
     t.string "country_of_origin"
     t.string "original_title"
+    t.json "cover_image_srcsets"
+    t.json "sample_pages_srcsets"
     t.index ["country_of_origin"], name: "index_books_on_country_of_origin"
     t.index ["publisher_id"], name: "index_books_on_publisher_id"
     t.index ["slug"], name: "index_books_on_slug", unique: true

--- a/lib/tasks/bokatidindi.rake
+++ b/lib/tasks/bokatidindi.rake
@@ -232,4 +232,14 @@ namespace :bt do
       ActiveRecord::Base.connection.execute("SELECT pg_prewarm('#{t}')")
     end
   end
+
+  desc 'Update image variant urls'
+  task set_image_variant_urls: :environment do
+    Book.current.each do |b|
+      if b.cover_image.attached? || b.sample_pages.attached?
+        b.update_srcsets
+        b.save
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of relying on ActiveStorage, we are not using JSON database columns to store information about image variants as arrays of srcset strings.

This applies to both cover images and sample pages.

This should speed things up.