### PR TITLE
Fixing by_author scope

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -126,7 +126,13 @@ class Book < ApplicationRecord
   scope :by_publisher, ->(publisher_id) { where(publisher_id:) }
 
   scope :by_author, lambda { |author_id|
-    includes(:book_authors).where(book_authors: { author_id: })
+    includes(
+      :book_authors
+    ).where(
+      book_authors: { author_id: }
+    ).left_joins(
+      :book_authors
+    )
   }
 
   def inactive_edition_ids


### PR DESCRIPTION
Adding a left_join statement to the by_author book scope as without it, only that author is listed is the one we're filtering by.