### PR TITLE
Tweaking breakpoints and markup

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -43,7 +43,7 @@ $grid-breakpoints: (
   sm:   576px,
   md:   670px,
   lg:   992px,
-  xl:   1600px,
+  xl:   1400px,
   xxl:  2000ox
 ) ;
 
@@ -171,6 +171,7 @@ main {
     }
     a {
       font-weight: $font-weight-bold;
+      padding: 3px 0;
     }
   }
 
@@ -209,6 +210,7 @@ main {
   #book-binding-types {
     a {
       font-weight: $font-weight-bold;
+      padding: 3px 0;
     }
     h3 {
       font-family: $montserrat;

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -3,7 +3,7 @@
   <% @books.each do |book| %>
   <section
     id="book-<%= book.id %>"
-    class="book col-12 col-md-6 col-xl-4"
+    class="book col-12 col-md-6 col-xl-4 px-0"
     aria-labelledby="book-<%= book.id %>-hgroup"
   >
 
@@ -34,7 +34,6 @@
 
       <div
         class="mt-1 col-lg-4 overflow-hidden order-0"
-        aria-hidden="true"
       >
         <a class="product-image-link" href="<%= book_path(book.slug) %>" tabindex="-1">
           <figure class="figure mt-4 w-100">

--- a/app/views/books/_results_heading.html.erb
+++ b/app/views/books/_results_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-12 pl-5 pb-3">
+  <div class="col-12 pb-3">
     <% unless params[:publisher] || params[:category] || params[:author] || params[:search] %>
       <h1>Allar bækur</h1>
     <% else %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -20,7 +20,7 @@
 
 <main role="main" aria-label="Bækur">
 
-  <div class="container-fluid">
+  <div class="container-fluid px-5">
 
     <%= render 'books/results_heading' %>
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -138,6 +138,7 @@
           </a>
         </figure>
 
+        <% if @book.sample_pages.any? %>
         <div
           class="preview-images align-self-end row"
           aria-label="Sýnishorn úr bók"
@@ -163,6 +164,7 @@
           </a>
           <% end %>
         </div>
+        <% end %>
 
         <div>
           <%= render 'books/meta', book: @book %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="row mb-5 p-4 pt-2 justify-content-between align-items-end">
+<header class="row mb-5 px-4 pb-3 pt-4 pt-sm-0 justify-content-between align-items-end">
   <nav aria-label="Aftur á forsíðu" class="site-logo order-2 col-9 col-xl-3 col-lg-4 col-md-4 col-sm-12">
     <a href="<%= root_path %>" title="Fara á forsíðu Bókatíðinda">
       <%= image_tag 'logotype-cropped.svg', height: '105', width: '689', alt: 'Bókatíðindi', class: 'img-fluid' %>

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -11,7 +11,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.min.js" integrity="sha384-kjU+l4N0Yf4ZOJErLsIcvOU2qSb74wXpOhqTvwVx3OElZRweTnQ6d31fXEoRD1Jy" crossorigin="anonymous"></script>
 
 <%= stylesheet_link_tag 'application', media: 'all' %>
-<%= javascript_include_tag 'application.js' %>
+<%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= yield :meta %>
     <%= render 'layouts/meta' %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
   <body>


### PR DESCRIPTION
- XL breakpoint is now at 1400 px to account for MacBook Pro
- Gutter between columns in the book index has been reduced to zero.
- Sample pages container is removed from markup if there are no samples to show
- The application JS was being requested twice and that has been fixed