### PR TITLE
Removing compiled JS

### DIFF
--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -11,7 +11,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.min.js" integrity="sha384-kjU+l4N0Yf4ZOJErLsIcvOU2qSb74wXpOhqTvwVx3OElZRweTnQ6d31fXEoRD1Jy" crossorigin="anonymous"></script>
 
 <%= stylesheet_link_tag 'application', media: 'all' %>
-<%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@
     devtool: "source-map",
     entry: {
       application: [
-        "./app/javascript/application.js",
         "./app/assets/stylesheets/application.scss",
       ],
       custom: './app/assets/stylesheets/custom.scss'
@@ -41,7 +40,7 @@
   },
   resolve: {
     // Add additional file types
-    extensions: ['.js', '.jsx', '.scss', '.css'],
+    extensions: ['.scss', '.css'],
   },
   plugins: [
     new RemoveEmptyScriptsPlugin(),


### PR DESCRIPTION
Those resources are loaded from external CDNs via HTTP/2, so this is not needed anymore.