### PR TITLE
Adapting result pages closer to UX designs

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -86,6 +86,10 @@ body {
   min-height: 100vh;
 }
 
+h1 {
+  font-weight: 600;
+}
+
 a {
   text-decoration: underline;
 }

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -51,6 +51,7 @@
               <% if i > 5 %>
               loading="lazy"
               <% end %>
+              alt="Bókakápa: <%= book.full_title_noshy %>"
             >
           </figure>
         </a>

--- a/app/views/books/_results_heading.html.erb
+++ b/app/views/books/_results_heading.html.erb
@@ -1,31 +1,20 @@
 <div class="row">
   <div class="col-12 pb-3">
-    <% unless params[:publisher] || params[:category] || params[:author] || params[:search] %>
-      <h1>Allar bækur</h1>
-    <% else %>
-      <h1>Niðurstöður</h1>
-    <ul class="d-block p-0">
+    <h1>
+      <% unless params[:publisher] || params[:category] || params[:author] || params[:search] %>
+        Allar bækur
+      <% end %>
       <% unless params[:author].nil? %>
-      <li class="d-inline-block badge badge-darkgrey">
-        <%= @author.name %>
-      </li>
+        Höfundur: <%= @author.name %>
       <% end %>
       <% unless params[:publisher].nil? %>
-      <li class="d-inline-block badge badge-darkgrey">
-        <%= @publisher.name %>
-      </li>
+        Útgefandi: <%= @publisher.name %>
       <% end %>
       <% unless params[:category].nil? %>
-      <li class="d-inline-block badge badge-darkgrey">
         <%= @category.name_with_group %>
-      </li>
       <% end %>
       <% unless params[:search].nil? %>
-      <li class="d-inline-block badge badge-darkgrey">
-        <%= params[:search] %>
-      </li>
+        Leitarorð: <%= params[:search] %>
       <% end %>
-    </ul>
-    <% end %>
   </div>
 </div>


### PR DESCRIPTION
- Heading element is now in a thicker bold
- Simplifying result headings, removing the badge
- Adding alt text to book covers to shut Google Lighthouse up