### PR TITLE
Simplifying responsive images

### DIFF
--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -46,21 +46,7 @@
               <% unless book.cover_image_srcsets.blank? %>
               srcset="<%= book.cover_image_srcsets[@image_format] %>"
               sizes="
-                ( min-width: 2000px ) and ( max-resolution: 200dpi ) 260px,
-                ( min-width: 2000px ) and ( min-resolution: 200dpi ) 550px,
-
-                ( min-width: 1400px ) and ( max-resolution: 200dpi ) 150px,
-                ( min-width: 1400px ) and ( min-resolution: 200dpi ) 260px,
-
-                ( min-width: 992px ) and ( max-resolution: 200dpi ) 150px,
-                ( min-width: 992px ) and ( min-resolution: 200dpi ) 260px,
-
-                ( min-width: 670px ) and ( max-resolution: 200dpi ) 150px,
-                ( min-width: 670px ) and ( min-resolution: 200dpi ) 260px,
-
-                ( min-width: 576px ) and ( max-resolution: 200dpi ) 550px,
-                ( min-width: 576px ) and ( min-resolution: 200dpi ) 1200px,
-
+                ( min-width: 576px ) 150px,
                 (max-width: 576px ) 260px
               "
               <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -134,21 +134,11 @@
               <% unless @book.cover_image_srcsets.blank? %>
               srcset="<%= @book.cover_image_srcsets[@image_format] %>"
               sizes="
-                ( min-width: 2000px ) and ( max-resolution: 200dpi ) 1200px,
-                ( min-width: 2000px ) and ( min-resolution: 200dpi ) 1600px,
-
-                ( min-width: 1400px ) and ( max-resolution: 200dpi ) 550px,
-                ( min-width: 1400px ) and ( min-resolution: 200dpi ) 1200px,
-
-                ( min-width: 992px ) and ( max-resolution: 200dpi ) 260px,
-                ( min-width: 992px ) and ( min-resolution: 200dpi ) 550px,
-
-                ( min-width: 670px ) and ( max-resolution: 200dpi ) 150px,
-                ( min-width: 670px ) and ( min-resolution: 200dpi ) 260px,
-
-                ( min-width: 576px ) and ( max-resolution: 200dpi ) 550px,
-                ( min-width: 576px ) and ( min-resolution: 200dpi ) 1200px,
-
+                ( min-width: 2000px ) 1200px,
+                ( min-width: 1400px ) 550px,
+                ( min-width: 992px ) 260px,
+                ( min-width: 670px ) 150px,
+                ( min-width: 576px ) 550px,
                 (max-width: 576px ) 260px
               "
               <% end %>


### PR DESCRIPTION
Apparantly, browsers tend to override resoltion selectors anyway, so we can cut this down.