### PR TITLE
Fixing bodged search redirect

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,9 @@ class BooksController < ApplicationController
 
     if params[:search]
       render_search
-      return redirect_to book_path(@books.first[:slug]) if @books.length == 1
+      if @books.length + @books_from_old_editions.length == 1
+        redirect_to book_path(@books.first[:slug])
+      end
     else
       render_category if params[:category]
       render_publisher if params[:publisher]

--- a/app/models/book_binding_type.rb
+++ b/app/models/book_binding_type.rb
@@ -18,9 +18,9 @@ class BookBindingType < ApplicationRecord
 
   validates(
     :barcode, isbn_format: {
-                with: :isbn13,
-                message: 'þarf að vera gilt ISBN-13-númer'
-              },
+      with: :isbn13,
+      message: 'þarf að vera gilt ISBN-13-númer'
+    },
               unless: proc { |bbt| bbt.barcode.blank? },
               if: proc { |bbt| bbt&.binding_type&.barcode_type == 'ISBN' }
   )

--- a/app/models/book_binding_type.rb
+++ b/app/models/book_binding_type.rb
@@ -18,9 +18,9 @@ class BookBindingType < ApplicationRecord
 
   validates(
     :barcode, isbn_format: {
-      with: :isbn13,
-      message: 'þarf að vera gilt ISBN-13-númer'
-    },
+                with: :isbn13,
+                message: 'þarf að vera gilt ISBN-13-númer'
+              },
               unless: proc { |bbt| bbt.barcode.blank? },
               if: proc { |bbt| bbt&.binding_type&.barcode_type == 'ISBN' }
   )

--- a/app/models/book_edition.rb
+++ b/app/models/book_edition.rb
@@ -49,7 +49,7 @@ class BookEdition < ApplicationRecord
 
   def create_book_edition_categories
     book.book_categories.each do |bc|
-      next unless (Edition.current.ids).include?(edition.id)
+      next unless Edition.current.ids.include?(edition.id)
 
       for_print = if bc.for_print == true
                     if edition.print_registration_over?


### PR DESCRIPTION
Fixing an issue where a redirect occurs when a search term has a single appearance in the current edition but there are results in older editions.