### PR TITLE
Fixing search redirect issue

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,8 +6,9 @@ class BooksController < ApplicationController
 
     if params[:search]
       render_search
-      if @books.length + @books_from_old_editions.length == 1
-        redirect_to book_path(@books.first[:slug])
+      book_results = @books + @books_from_old_editions
+      if book_results.length == 1
+        redirect_to book_path(book_results.first[:slug])
       end
     else
       render_category if params[:category]


### PR DESCRIPTION
The search redirects to the only book in search results containing only a single book. When the only result was from an older edition, it resulted in a 500 error instead of redirecting.