### PR TITLE
Stripping emoji from descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,3 +118,5 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "good_job", "~> 3.19"
+
+gem "unicode-emoji", "~> 3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,9 @@ GEM
     uber (0.1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
+    unicode-emoji (3.4.0)
+      unicode-version (~> 1.0)
+    unicode-version (1.3.0)
     uri (0.12.2)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
@@ -514,6 +517,7 @@ DEPENDENCIES
   thwait
   turbolinks (~> 5)
   tzinfo-data
+  unicode-emoji (~> 3.4)
   validate_url
   web-console (>= 4.1.0)
   webdrivers

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -232,12 +232,17 @@ class Book < ApplicationRecord
                                   .gsub('.  ', '. ')
                                   .gsub('`', '\'')
                                   .gsub('´', '\'')
+                                  .gsub(Unicode::Emoji::REGEX_WELL_FORMED, '')
                                   .strip&.upcase_first
 
     self.long_description = long_description.gsub(/[\r\n]+/, "\r\n\r\n")
                                             .gsub('.  ', '. ')
                                             .gsub('`', '\'')
                                             .gsub('´', '\'')
+                                            .gsub(
+                                              Unicode::Emoji::REGEX_WELL_FORMED,
+                                              ''
+                                            )
                                             .strip&.upcase_first
     nil
   end


### PR DESCRIPTION
This seems to have been dropped, as we decided a while ago to strip emoji from description text as a part of a sanitation process.