### PR TITLE
Adding a worker process for the good_jobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 release: rake db:migrate && rake bt:maintain_collation && rake bt:update_category_counters
 web: bundle exec puma -C config/puma.rb
+worker: good_job start


### PR DESCRIPTION
This removes the need to run good_jobs as a cron process.