### PR TITLE
Using ENV vars to configure job execution mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,6 @@ module Bokatidindi
     config.active_storage.variant_processor = :mini_magick
 
     config.active_job.queue_adapter = :good_job
-    config.good_job.execution_mode = :external
+    config.good_job.execution_mode = ENV['JOB_EXECUTION_MODE']&.to_sym || :async
   end
 end


### PR DESCRIPTION
This defaults on `:async`, which runs the jobs as a part of the web server process, but during high season, this should be set to `:external`, which uses an external worker node.