### PR TITLE
Switching image processing to vips

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         bundler-cache: true
     - name: Install required apt packages
-      run: sudo apt-get -y install libpq-dev
+      run: sudo apt-get -y install libpq-dev libvips42
     - name: Run bundle install
       run: bundle install && yarn install
     - name: Load the database schema

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -532,16 +532,16 @@ class Book < ApplicationRecord
   end
 
   def attach_print_image_variant
-    cover_image.variant(resize_to_limit: [325, nil], units: 'PixelsPerInch',
-                        density: 330, format: 'tiff').process
+    cover_image.variant(resize_to_limit: [325, nil],
+                        format: 'tiff', saver: { dpi: 330 }).process
   end
 
   def print_image_variant_url
     cover_variant = cover_image.variant(resize_to_limit: [325, nil],
-                                        units: 'PixelsPerInch',
-                                        density: 330, format: 'tiff')
+                                        format: 'tiff',
+                                        saver: { dpi: 330 })
 
-    if ActiveStorage::Blob.service.name.to_s == 'local'
+    if ActiveStorage::Blob.service.name == :local
       return Rails.application.routes.url_helpers.url_for(cover_variant)
     end
 
@@ -566,7 +566,7 @@ class Book < ApplicationRecord
 
   def attach_cover_image_variant(image_format, width = nil)
     if width
-      return cover_image.variant(resize_to_limit: [width, width],
+      return cover_image.variant(resize_to_limit: [width, nil],
                                  format: image_format,
                                  saver: { quality: IMAGE_QUALITY }).process
     end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -38,6 +38,8 @@ class Book < ApplicationRecord
   CATEGORIES_SEARCH_COLUMNS        = %i[origin_name slug].freeze
   BOOK_BINDING_TYPE_SEARCH_COLUMNS = %i[barcode].freeze
 
+  PRINT_RES = 330 / 25.4
+
   multisearchable against: %i[pre_title title_noshy post_title description
                               long_description]
 
@@ -533,13 +535,16 @@ class Book < ApplicationRecord
 
   def attach_print_image_variant
     cover_image.variant(resize_to_limit: [325, nil],
-                        format: 'tiff', saver: { dpi: 330 }).process
+                        copy: { xres: PRINT_RES,
+                                yres: PRINT_RES },
+                        format: 'tiff').process
   end
 
   def print_image_variant_url
     cover_variant = cover_image.variant(resize_to_limit: [325, nil],
-                                        format: 'tiff',
-                                        saver: { dpi: 330 })
+                                        copy: { xres: PRINT_RES,
+                                                yres: PRINT_RES },
+                                        format: 'tiff')
 
     if ActiveStorage::Blob.service.name == :local
       return Rails.application.routes.url_helpers.url_for(cover_variant)

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Bokatidindi
     config.i18n.available_locales = [:is]
     config.i18n.default_locale = :is
 
-    config.active_storage.variant_processor = :mini_magick
+    config.active_storage.variant_processor = :vips
 
     config.active_job.queue_adapter = :good_job
     config.good_job.execution_mode = ENV['JOB_EXECUTION_MODE']&.to_sym || :async


### PR DESCRIPTION
Vips is a faster and more efficient image processing library and the current Rails default. However, we have to make sure that the TIFF thumbnails for the printed edition work using vips, as it requires us to force a certain DPI/PPI value for them.