### PR TITLE
Fixing a 500 error for Pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class Page < ApplicationRecord
+  def self.ransackable_associations(_auth_object = nil)
+    reflect_on_all_associations.map { |a| a.name.to_s }
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    column_names
+  end
 end


### PR DESCRIPTION
I forgot to set the `ransackable_associations` and `ransackable_associations` methods for this one last year, so it was broken in ActiveAdmin. It should be fixed now.