### PR TITLE
Changing book LD+JSON to article

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -13,6 +13,7 @@ class WelcomeController < ApplicationController
     expires_in 1.hour, public: true
 
     @website_ld_json = ld_json
+    @org_ld_json     = ld_json_org
 
     @page_content = Page.find_by(slug: 'forsida')
     @image_format = image_format
@@ -29,30 +30,37 @@ class WelcomeController < ApplicationController
   def ld_json
     {
       '@context': 'https://schema.org/',
+      '@id': 'https://www.bokatidindi.is/',
       '@type': ['WebSite', 'Periodical'],
       name: 'Bókatíðindi',
       about: META_DESCRIPTION,
       inLanguage: 'is',
-      publisher: {
-        '@type': ['Organization'],
-        name: 'Félag íslenskra bókaútgefenda',
-        address: {
-          '@type': 'PostalAddress',
-          addressLocality: 'Reykjavík',
-          postalCode: '101',
-          streetAddress: 'Barónsstíg 5',
-          addressCountry: 'IS'
-        },
-        image: [
-          ActionController::Base.helpers.asset_url('favicon-512.png'),
-          ActionController::Base.helpers.asset_url('logotype-cropped.svg')
-        ]
-      },
+      maintainer: ld_json_org,
+      image: [
+        ActionController::Base.helpers.asset_url('favicon-512.png'),
+        ActionController::Base.helpers.asset_url('logotype-cropped.svg')
+      ],
       url: 'https://www.bokatidindi.is/',
       potentialAction: {
         '@type': 'SearchAction',
         target: 'https://www.bokatidindi.is/baekur?search={search_term_string}',
         'query-input': 'required name=search_term_string'
+      }
+    }
+  end
+
+  def ld_json_org
+    {
+      '@type': ['Organization'],
+      name: 'Félag íslenskra bókaútgefenda',
+      alternateName: 'FÍBÚT',
+      url: 'https://fibut.is/',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Reykjavík',
+        postalCode: '101',
+        streetAddress: 'Barónsstíg 5',
+        addressCountry: 'IS'
       }
     }
   end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -66,7 +66,8 @@ class Author < ApplicationRecord
   def structured_data
     {
       '@type': 'Person',
-      'name': name
+      name: name,
+      url: "https://www.bokatidindi.is/baekur/hofundur/#{slug}"
     }
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -163,30 +163,113 @@ class Book < ApplicationRecord
     column_names
   end
 
+  def structured_data_article
+    result = {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      '@id': "https://www.bokatidindi.is/bok/#{slug}",
+      '@url': "https://www.bokatidindi.is/bok/#{slug}",
+      additionalType: ['AdvertiserContentArticle'],
+      headline: full_title_noshy,
+      description: description,
+      isPartOf: structured_data_publication,
+      image: [],
+      maintainer: publisher.ld_json,
+      dateModified: updated_at,
+      datePublished: created_at
+    }
+
+    result[:image] << cover_image_url('jpg') if cover_image.attached?
+
+    sample_pages.each_with_index do |_sp, i|
+      result[:image] << sample_page_url(i, 'jpg')
+    end
+
+    result
+  end
+
   def structured_data
     result = {
       '@context': 'https://schema.org',
       '@type': 'Book',
-      'name': full_title_noshy,
-      'description': description,
-      'publisher': publisher.name
+      '@id': "https://www.bokatidindi.is/bok/#{slug}",
+      '@url': "https://www.bokatidindi.is/bok/#{slug}",
+      name: full_title_noshy,
+      author: structured_data_authors,
+      description: description,
+      review: structured_data_reviews,
+      isbn: book_binding_types.pluck(:barcode),
+      publisher: publisher.ld_json,
+      dateModified: updated_at
     }
 
-    result['isbn'] = structured_data_isbn unless structured_data_isbn.empty?
-
-    unless structured_data_author.empty?
-      result['author'] = structured_data_author
-    end
-
     unless structured_data_translator.empty?
-      result['translator'] = structured_data_translator
+      result[:translator] = structured_data_translator
     end
 
-    result['sameAs'] = structured_data_url unless structured_data_url.empty?
+    result[:sameAs] = structured_data_url unless structured_data_url.empty?
 
-    result['image'] = cover_image_url if cover_image.attached?
+    result[:image] = cover_image_url('jpg') if cover_image.attached?
+
+    sample_pages.each_with_index do |_sp, i|
+      result[:image] << sample_page_url(i, 'jpg')
+    end
 
     result
+  end
+
+  def structured_data_publication
+    result = {
+      '@context': 'https://schema.org/',
+      '@id': 'https://www.bokatidindi.is/',
+      '@type': ['WebSite', 'Periodical'],
+      name: 'Bókatíðindi',
+      abstract: WelcomeController::META_DESCRIPTION,
+      inLanguage: 'is',
+      image: [
+        ActionController::Base.helpers.asset_url('favicon-512.png'),
+        ActionController::Base.helpers.asset_url('logotype-cropped.svg')
+      ],
+      maintainer: structured_data_fibut,
+      url: 'https://www.bokatidindi.is/',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://www.bokatidindi.is/baekur?search={search_term_string}',
+        'query-input': 'required name=search_term_string'
+      }
+    }
+
+    temporal_coverage = editions.pluck(:year) - [nil]
+
+    result[:temporalCoverage] = temporal_coverage if temporal_coverage.any?
+
+    result
+  end
+
+  def structured_data_fibut
+    {
+      '@type': ['Organization'],
+      name: 'Félag íslenskra bókaútgefenda',
+      alternateName: 'FÍBÚT',
+      url: 'https://fibut.is/',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Reykjavík',
+        postalCode: '101',
+        streetAddress: 'Barónsstíg 5',
+        addressCountry: 'IS'
+      }
+    }
+  end
+
+  def structured_data_reviews
+    blockquotes.map do |bq|
+      {
+        '@type': 'Review',
+        reviewBody: bq.quote,
+        author: bq.citation
+      }
+    end
   end
 
   def structured_data_isbn
@@ -201,40 +284,15 @@ class Book < ApplicationRecord
     book_binding_types.where.not(url: '').pluck(:url).uniq
   end
 
-  def structured_data_author
-    selected_book_authors = book_authors.includes(:author_type).where(
-      author_type: { name: ['Höfundur', 'Myndhöfundur'] }
-    )
-
-    results = []
-
-    selected_book_authors.each do |ba|
-      results << ba.author.structured_data
+  def structured_data_authors
+    book_authors.includes(:author_type, :author).map do |ba|
+      {
+        '@type': 'Person',
+        name: ba.name,
+        jobTitle: ba.author_type.name,
+        url: "https://www.bokatidindi.is/baekur/hofundur/#{ba.author.slug}"
+      }
     end
-
-    results
-  end
-
-  def structured_data_translator
-    selected_book_authors = book_authors.includes(:author_type).where(
-      author_type: { name: 'Þýðandi' }
-    )
-
-    results = []
-
-    selected_book_authors.each do |ba|
-      results << ba.author.structured_data
-    end
-
-    results
-  end
-
-  def main_authors_ids
-    book_authors.where(
-      author_type_id: 2
-    ).pluck(
-      :author_id
-    )
   end
 
   def main_authors_string

--- a/app/models/book_author.rb
+++ b/app/models/book_author.rb
@@ -19,4 +19,13 @@ class BookAuthor < ApplicationRecord
   def name
     [author.firstname, author.lastname].join(' ')
   end
+
+  def structured_data
+    {
+      '@type': 'Person',
+      name: name,
+      jobTitle: author_type.name,
+      url: "https://www.bokatidindi.is/baekur/hofundur/#{slug}"
+    }
+  end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -28,7 +28,25 @@ class Publisher < ApplicationRecord
     ).count
   end
 
+  def ld_json
+    {
+      '@id': "https://www.bokatidindi.is/baekur/utgefandi/#{slug}",
+      '@type': 'Organization',
+      url: ld_json_urls,
+      name: name
+    }
+  end
+
   private
+
+  def ld_json_urls
+    urls = ["https://www.bokatidindi.is/baekur/utgefandi/#{slug}"]
+    urls << url if URI(url).scheme
+
+    return urls.first if urls.length == 1
+
+    urls
+  end
 
   def set_slug
     self.slug = name.parameterize(locale: :is)

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -4,12 +4,17 @@
   <%= tag 'meta', name: 'description', content: html_escape_once(strip_tags(@book.description).squish) %>
   <%= tag 'link', rel: 'canonical', href: url_for(controller: 'books', action: 'show', only_path: false) %>
 
+  <%= tag 'meta', name: 'thumbnail', content: @book.cover_image_url('jpg') %>
+
   <%= tag 'meta', property: 'og:type', content: 'book' %>
   <% @book.book_authors.joins(:author_type, :author).where(author_type: { name: 'Höfundur' }).each do |a| %>
   <%= tag 'meta', property: 'book:author', content: a.author.name %>
   <% end %>
   <% if @book.cover_image.attached? %>
-  <%= tag 'meta', property: 'og:image', content: @book.cover_image_variant_url(1200, @image_format) %>
+  <%= tag 'meta', property: 'og:image', content: @book.cover_image_url('jpg') %>
+  <% @book.sample_pages.each_with_index do |_sp, i| %>
+  <%= tag 'meta', property: 'og:image', content: @book.sample_page_url(i, 'jpg') %>
+  <% end %>
   <%= tag 'meta', property: 'og:image:width', content: @book.cover_image.metadata[:width] %>
   <%= tag 'meta', property: 'og:image:height', content: @book.cover_image.metadata[:height] %>
   <% end %>
@@ -27,7 +32,7 @@
   <%= tag 'meta', name: 'twitter:title', content: html_escape_once(@book.full_title_with_author) %>
   <%= tag 'meta', name: 'twitter:description', content: html_escape_once(strip_tags(@book.description).squish) %>
   <% if @book.cover_image.attached? %>
-  <%= tag 'meta', name: 'twitter:image', content: @book.cover_image_variant_url(1200, 'jpg') %>
+  <%= tag 'meta', name: 'twitter:image', content: @book.cover_image_url('jpg') %>
   <% end %>
 
   <% if @book.cover_image_srcsets.kind_of?(Array) %>
@@ -41,7 +46,9 @@
   %>
   <% end %>
 
-  <script type="application/ld+json"><%= raw @book.structured_data.to_json %></script>
+  <script type="application/ld+json">
+  <%= raw JSON.pretty_generate @book.structured_data_article %>
+  </script>
 
   <script type="module">
   import { Fancybox } from "https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0.36/dist/fancybox/fancybox.esm.min.js";
@@ -123,7 +130,7 @@
           <% end %>
 
           <article id="book_long_description">
-            <%=  simple_format @book.long_description, tags: ['em'] %>
+            <%= simple_format @book.long_description, tags: ['em'] %>
           </article>
 
           <% @book.blockquotes.where(location: :below_long_description).each do |blockquote, i| %>
@@ -189,10 +196,11 @@
             class="preview-image-link col-6 col-lg-3 mb-2"
             data-fancybox="samples"
             href="<%= @book.sample_page_url(i, @image_format) %>"
-            title="Skoða sýnidæmi"
+            title="Skoða sýnidæmi <%= i + 1 %>"
           >
             <img
               class="img-fluid"
+              src="<%= @book.sample_page_url(i, @image_format) %>"
               <% unless @book.sample_pages_srcsets[@image_format].empty? %>
               srcset="<%= @book.sample_pages_srcsets[@image_format][i].join(', ') %>"
               sizes="(max-width: 576px) 150px, (max-width: 1200px) 550px, 150px"


### PR DESCRIPTION
Turns out that Google only wants us to be *selling* books directly in order for the Book LD+JSON datatype to be useful for us. This has promted a restucture of how we use LD+JSON, so we're replacing Book with Article.