### PR TITLE
Reverting preloaded cover image preloads

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -13,7 +13,7 @@ class BooksController < ApplicationController
                    '(min-width: 720px) 550px, '\
                    '(min-width: 670px) 260px, '\
                    '(min-width: 420px) 550px, '\
-                   '(min-width: 460px) 260px'
+                   '(max-width: 420px) 260px'
 
     if params[:search]
       render_search

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -22,12 +22,6 @@
   <%= tag 'meta', name: 'twitter:description', content: @meta_description %>
   <%= tag 'meta', name: 'twitter:image', content: asset_path('favicon-512.png') %>
 
-  <% @books.first(6).each_with_index do |book,i| %>
-  <% if book.cover_image.attached? %>
-  <%= tag 'link', rel: 'preload', as: 'image', href: book.cover_image_url, imagesrcset: book.cover_image_srcsets[@image_format], imagesizes: @image_sizes %>
-  <% end %>
-  <% end %>
-
   <% if @itemlist_ld_json %>
   <script type="application/ld+json"><%= raw @itemlist_ld_json.to_json %></script>
   <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -34,17 +34,6 @@
   <%= tag 'meta', name: 'twitter:image', content: @book.cover_image_url('jpg') %>
   <% end %>
 
-  <% if @book.cover_image_srcsets.kind_of?(Array) %>
-  <%=
-  tag(
-    'link',
-    rel: 'preload', as: 'image', href: @book.cover_image_url,
-    imagesrcset: @book.cover_image_srcsets[@image_format],
-    imagesizes: @image_sizes, type: "image/#{@image_format}"
-  )
-  %>
-  <% end %>
-
   <script type="application/ld+json">
   <%= raw @book.structured_data.to_json %>
   </script>


### PR DESCRIPTION
Preloading is not as effective as I thought. Besides, the viewport size seems to be unknown before rendering so the largest image size is preloaded instead of the appropriate one for the viewport.

But it is no biggie, as lazy loading images below the fold is more effective than preloading large static images.