### PR TITLE
Fixng book title markup

### DIFF
--- a/app/views/books/_hgroup.erb
+++ b/app/views/books/_hgroup.erb
@@ -14,6 +14,6 @@
   </h1>
 
   <% unless local_assigns[:book].post_title.empty? %>
-    <h2 class="post-title mb-0"><%= raw local_assigns[:book].post_title %></h2>
+    <p class="post-title h3 pt-2 mb-0"><%= raw local_assigns[:book].post_title %></p>
   <% end %>
 </hgroup>

--- a/app/views/books/_hgroup_results.html.erb
+++ b/app/views/books/_hgroup_results.html.erb
@@ -8,6 +8,6 @@
   </h2>
 
   <% unless local_assigns[:book].post_title.empty? %>
-    <h3 class="post-title mb-0"><%= Shyguy.display_shy(raw local_assigns[:book].post_title) %></h3>
+    <p class="post-title h3 mb-0"><%= Shyguy.display_shy(raw local_assigns[:book].post_title) %></p>
   <% end %>
 </hgroup>


### PR DESCRIPTION
Moving <hgroup> elements closer to the current HTML 5 standard.