### PR TITLE
Removing "current" condition for author listings

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -100,7 +100,7 @@ class BooksController < ApplicationController
 
     author_books = Book.by_author(@author)
 
-    @books = author_books.current.with_attached_cover_image.order(:title)
+    @books = author_books.with_attached_cover_image.order(:title)
                          .page(params[:page])
 
     @books_from_old_editions = author_books - @books


### PR DESCRIPTION
We were returning a 404 error for authors who's books aren't in the current edition. This fixes that.