### PR TITLE
Updating ActiveAdmin to 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,3 +121,11 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "good_job", "~> 3.19"
 
 gem "unicode-emoji", "~> 3.4"
+
+gem "logger", "~> 1.6"
+
+gem "concurrent-ruby", "= 1.3.4"
+
+gem "reline", "~> 0.6.0"
+
+gem "irb", "~> 1.15"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activeadmin (3.2.5)
+    activeadmin (3.3.0)
       arbre (~> 1.2, >= 1.2.1)
       csv
       formtastic (>= 3.1)
@@ -112,7 +112,7 @@ GEM
     country_select (8.0.3)
       countries (~> 5.0)
     crass (1.0.6)
-    csv (3.3.0)
+    csv (3.3.2)
     database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -131,7 +131,7 @@ GEM
     drb (2.2.1)
     e2mmap (0.1.0)
     ean13 (2.0.2)
-    erubi (1.13.0)
+    erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
     factory_bot (6.5.0)
@@ -203,7 +203,7 @@ GEM
       activesupport (>= 5.2)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.13.0)
       mini_magick (>= 4.9.5, < 5)
@@ -213,6 +213,11 @@ GEM
       has_scope (>= 0.6)
       railties (>= 6.0)
       responders (>= 2)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     isbn-calculator (1.0.0)
     isbn_validation (1.2.2)
       activerecord (>= 3)
@@ -249,7 +254,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.1)
-    loofah (2.22.0)
+    loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -266,7 +271,7 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.1)
+    minitest (5.25.5)
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
@@ -300,13 +305,19 @@ GEM
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     public_suffix (6.0.1)
     puma (5.6.9)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.14)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rack-timeout (0.7.0)
     rails (7.0.8.7)
@@ -342,15 +353,19 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
-    ransack (4.2.1)
+    ransack (4.3.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     redcarpet (3.6.0)
     regexp_parser (2.9.3)
+    reline (0.6.0)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -471,7 +486,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   ruby
@@ -487,6 +502,7 @@ DEPENDENCIES
   cancancan
   capybara (>= 3.26)
   cocoon
+  concurrent-ruby (= 1.3.4)
   country_select (~> 8.0.3)
   database_cleaner-active_record
   devise
@@ -499,6 +515,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.11)
   htmlentities
   image_processing (~> 1.12)
+  irb (~> 1.15)
   isbn-calculator
   isbn_validation
   iso-639
@@ -508,6 +525,7 @@ DEPENDENCIES
   kaminari (>= 1.2.0)
   library_stdnums
   listen (~> 3.3)
+  logger (~> 1.6)
   mimemagic
   mysql2 (>= 0.5.3)
   nokogiri (~> 1.18.8)
@@ -521,6 +539,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-html-sanitizer (~> 1.4.4)
   redcarpet
+  reline (~> 0.6.0)
   rspec-rails (>= 6.0.0.rc1)
   rubocop (~> 1.69.2)
   rubocop-rails

--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -98,6 +98,11 @@ ActiveAdmin.register AdminUser do
     end
   end
 
+  filter :name_cont, label: 'Nafn inniheldur'
+  filter :email_cont, label: 'Tölvupótfang inniheldur'
+  filter :publishers, as: :select
+  filter :role, as: :check_boxes, collection: AdminUser.roles
+
   index do
     selectable_column
     column :name do |admin_user|
@@ -111,10 +116,6 @@ ActiveAdmin.register AdminUser do
     column :locked_at
     actions
   end
-
-  filter :name
-  filter :email
-  filter :publishers, as: :select
 
   form do |f|
     f.semantic_errors

--- a/app/admin/authors.rb
+++ b/app/admin/authors.rb
@@ -3,10 +3,10 @@
 ActiveAdmin.register Author do
   config.sort_order = 'order_by_name_asc'
 
-  permit_params :firstname, :lastname, :is_icelandic, :schema_type
+  permit_params :firstname, :lastname, :is_icelandic, :schema_type,
+                :firstname_contains, :firstname_contains
 
-  filter :firstname_contains
-  filter :lastname_contains
+  filter :name_cont, label: 'Nafn inniheldur'
 
   index do
     selectable_column
@@ -41,8 +41,7 @@ ActiveAdmin.register Author do
       para 'Athugið að og einn einstakling úr hópi eða tvíeyki þarf að skrá '\
            'sérstaklega og með fullu nafni.'
       para 'Fornafn og eftirnafn höfundar er skráð í sitt hvorn reitinn.'
-      para 'Munið einnig að skrá kyn höfundar svo rétt sé og hvort höfundur '\
-           'sé íslenskur eða erlendur.'
+      para 'Munið einnig að skrá hvort höfundur sé íslenskur eða erlendur.'
     end
 
     f.inputs 'Nafn' do

--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -233,10 +233,11 @@ ActiveAdmin.register Book do
   scope 'Allar', :all
   scope 'Í núverandi tbl.', :current
 
-  filter :title_contains
-  filter :description_contains
+  filter :title_cont, label: 'Titill inniheldur'
+  filter :description_cont, label: 'Lýsing inniheldur'
   filter :publisher
-  filter :id_equals
+  filter :slug_eq, label: 'Tilvísun'
+  filter :id_eq, label: 'Númer'
 
   includes :publisher, :authors
 

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -3,8 +3,9 @@
 ActiveAdmin.register Page do
   permit_params :title, :body, :slug
 
+  config.filters = false
+
   index do
-    selectable_column
     column :title
     column :body
     column :slug

--- a/app/admin/publishers.rb
+++ b/app/admin/publishers.rb
@@ -19,8 +19,6 @@ ActiveAdmin.register Publisher do
 
   permit_params :name, :email_address, :url, :schema_type
 
-  filter :name_contains
-
   controller do
     def build_new_resource
       super.tap do |r|
@@ -30,6 +28,8 @@ ActiveAdmin.register Publisher do
       end
     end
   end
+
+  filter :name_cont, label: 'Nafn inniheldur'
 
   index do
     selectable_column

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -16,6 +16,14 @@ class Author < ApplicationRecord
 
   validate :lastname_has_to_be_set_if_not_admin
 
+  def self.ransackable_attributes(_auth_object = nil)
+    ['name', 'is_icelandic']
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
+  end
+
   def lastname_has_to_be_set_if_not_admin
     return nil unless lastname.empty? && added_by.role != 'admin'
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -13,6 +13,10 @@ class Publisher < ApplicationRecord
   validates :email_address, format: { with: Devise.email_regexp },
                             allow_blank: true
 
+  def self.ransackable_attributes(_auth_object = nil)
+    ['name', 'created_at', 'updated_at']
+  end
+
   def book_edition_categories_by_edition_id(edition_id)
     BookEditionCategory.joins(
       book_edition: [book: [:publisher]]


### PR DESCRIPTION
This requires extensive rework around ransack attributes, as shorthand methods now replace "human readable" ones.

We also use the opportunity to optimise and rework some of the admin view.