### PR TITLE
Optimising frontend for 2025

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -110,7 +110,7 @@ class BooksController < ApplicationController
       @author[:name]
     )
 
-    return unless @books.page(params[:page]).out_of_range?
+    return if @books.page(params[:page]).any? || @books_from_old_editions.any?
 
     render file: 'public/404.html', status: :not_found, layout: false
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -337,6 +337,12 @@ class Book < ApplicationRecord
     cover_image.attached?
   end
 
+  def cover_image_proportions
+    return unless cover_image?
+
+    cover_image.metadata[:height] / cover_image.metadata[:width].to_f
+  end
+
   def audio_sample?
     audio_sample.attached?
   end

--- a/app/views/books/_ecommerce.erb
+++ b/app/views/books/_ecommerce.erb
@@ -5,7 +5,7 @@
 >
   <% if local_assigns[:book][:uri_to_buy] && !local_assigns[:book][:uri_to_buy].empty? %>
   <li class="my-2">
-    <a 
+    <a
       class="btn btn-lg btn-darkgrey"
       href="<%= local_assigns[:book].uri_to_buy %>"
       target="_blank"
@@ -16,7 +16,7 @@
   <% end %>
   <% if local_assigns[:book][:uri_to_audiobook] && !local_assigns[:book][:uri_to_audiobook].empty? %>
   <li class="my-2">
-    <a 
+    <a
       class="btn btn-darkgrey"
       href="<%= local_assigns[:book].uri_to_audiobook %>"
       target="_blank"

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -38,7 +38,11 @@
   <%= raw @book.structured_data.to_json %>
   </script>
 
-  <script type="module">
+  <%= tag 'link', rel: 'modulepreload', href: 'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0.36/dist/fancybox/fancybox.esm.min.js' %>
+<% end %>
+
+<% content_for :below_footer do %>
+<script type="module">
   import { Fancybox } from "https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0.36/dist/fancybox/fancybox.esm.min.js";
   Fancybox.bind('[data-fancybox="samples"]', {});
   Fancybox.defaults.l10n = {
@@ -49,15 +53,15 @@
     ERROR: "Eitthvað kom upp, reyndu aftur síðar",
     IMAGE_ERROR: "Myndin fannst ekki",
     ELEMENT_NOT_FOUND: "HTML-Element fannst ekki",
-    AJAX_NOT_FOUND: "Error Loading AJAX : Not Found",
-    AJAX_FORBIDDEN: "Error Loading AJAX : Forbidden",
-    IFRAME_ERROR: "Error Loading Page",
+    AJAX_NOT_FOUND: "Gat ekki sótt AJAX : Fannst ekki",
+    AJAX_FORBIDDEN: "Gat ekki sótt AJAX : Bannað",
+    IFRAME_ERROR: "Villa kom upp við að sækja síðu",
     TOGGLE_ZOOM: "Súma",
     TOGGLE_SLIDESHOW: "Sjálfvirk glærusýning",
     TOGGLE_FULLSCREEN: "Fullur skjár",
     TOGGLE_THUMBS: "Smámyndir"
   };
-  </script>
+</script>
 <% end %>
 
 <main class="m-md-5">
@@ -97,8 +101,8 @@
         <img
           src="<%= @book.cover_image_url %>"
           <% if @book.cover_image.attached? %>
-          height="<%= @book.cover_image.metadata[:height] %>"
-          width="<%= @book.cover_image.metadata[:width] %>"
+          height="<%= (550 * @book.cover_image_proportions).to_i %>"
+          width="<%= 550 %>"
           <% end %>
           <% unless @book.cover_image_srcsets.blank? %>
           srcset="<%= @book.cover_image_srcsets[@image_format] %>"
@@ -106,6 +110,7 @@
           <% end %>
           class="img-fluid w-100 d-md-none mb-5"
           alt="Forsíða kápu bókarinnar"
+          fetchpriority="high"
         >
 
         <div class="book-description mb-5 bt-5 overflow-hidden">
@@ -158,8 +163,8 @@
             <img
               <% if @book.cover_image.attached? %>
               src="<%= @book.cover_image_url %>"
-              height="<%= @book.cover_image.metadata[:height] %>"
-              width="<%= @book.cover_image.metadata[:width] %>"
+              height="<%= (550 * @book.cover_image_proportions).to_i %>"
+              width="<%= 550 %>"
               <% else %>
               src="<%= asset_url('blank.svg') %>"
               height="594"
@@ -221,4 +226,3 @@
 </div>
 
 </main>
-

--- a/app/views/layouts/_mobile_menu.erb
+++ b/app/views/layouts/_mobile_menu.erb
@@ -1,3 +1,27 @@
+<% content_for :below_footer do %>
+  <script>
+    function toggleMobileMenu(event) {
+      document.querySelector('#mobile-menu').classList.toggle('d-none');
+      document.querySelector('main').classList.toggle('d-none');
+      document.querySelector('footer.footer-container').classList.toggle('d-none');
+    }
+
+    function focusOnMobileMenu(event) {
+      document.querySelector('#mobile-menu').focus();
+    }
+
+    document.querySelector('#mobile-menu-button').addEventListener(
+      'click',
+      function() { toggleMobileMenu(); focusOnMobileMenu(); }
+    );
+
+    document.querySelector('#mobile-menu-close-button').addEventListener(
+      'click',
+      function() { toggleMobileMenu() }
+    );
+  </script>
+<% end %>
+
 <nav id="mobile-menu" aria-label="Aðalvalmynd" class="d-none">
   <button id="mobile-menu-close-button" class="btn btn-lightgrey" aria-label="Loka valmynd">
     <%= image_tag 'close_menu_button.svg', height: '16', width: '16', alt: '' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,27 +18,6 @@
 
     <%= render 'layouts/footer' %>
 
-    <script>
-      function toggleMobileMenu(event) {
-        document.querySelector('#mobile-menu').classList.toggle('d-none');
-        document.querySelector('main').classList.toggle('d-none');
-        document.querySelector('footer.footer-container').classList.toggle('d-none');
-      }
-
-      function focusOnMobileMenu(event) {
-        document.querySelector('#mobile-menu').focus();
-      }
-
-      document.querySelector('#mobile-menu-button').addEventListener(
-        'click',
-        function() { toggleMobileMenu(); focusOnMobileMenu(); }
-      );
-
-      document.querySelector('#mobile-menu-close-button').addEventListener(
-        'click',
-        function() { toggleMobileMenu() }
-      );
-    </script>
-
+    <%= yield :below_footer %>
   </body>
 </html>


### PR DESCRIPTION
- Moving footer JS into a separate partial called `:below_footer`.
- Preloading Fancybox and fixing translatable strings
- Fixing empty book index views, displaying 404 when needed
- Optimising cover image display
- Minor HTML fixes