### PR TITLE
Eliminating `.with_attached_cover_image` statements

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -43,7 +43,7 @@ class EditionsController < ApplicationController
       id: :asc
     ).where(
       book_editions: { edition_id: edition.id }
-    ).with_attached_cover_image.each do |b|
+    ).each do |b|
       book = edition_book(b, edition.id)
       if include_images && b.cover_image?
         book[:book_cover_image_url] = b.cover_image.url

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -20,7 +20,7 @@ class WelcomeController < ApplicationController
 
     @editions_with_cover = Edition.joins(
       :cover_image_attachment
-    ).with_attached_cover_image.current
+    ).current
   end
 
   def manifest

--- a/app/controllers/xml_feeds_controller.rb
+++ b/app/controllers/xml_feeds_controller.rb
@@ -107,7 +107,7 @@ class XmlFeedsController < ApplicationController
         edition_id
       ).by_category(
         c.id
-      ).with_attached_cover_image
+      )
 
       books = books.where(publisher_id:) unless publisher_id.nil?
 


### PR DESCRIPTION
From version 7.1 of Rails, calling `.with_attached_cover_image` queries the database for every single image variation in the database instead of the pervious expected behaviour, which was to only query for basic information about each ActiveStorage attachment.

This has caused massive delays in processing as well as timeout errors, so we are removing the eager loading statement and accepting the fact that we'll have a couple of n+1 queries instead.