### PR TITLE
Conditionally attaching cover image variants

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -675,6 +675,8 @@ class Book < ApplicationRecord
   end
 
   def attach_cover_image_variants
+    return nil unless cover_image.attached?
+
     attach_cover_image_variant('webp')
     attach_cover_image_variant('jpg')
     COVER_IMAGE_VARIANTS.each do |v|


### PR DESCRIPTION
If the cover image was missing, the background worker was errorinously attempting to generate images. This has now been fixed.