### PR TITLE
Removing structured data from induvidiual books

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -34,10 +34,6 @@
   <%= tag 'meta', name: 'twitter:image', content: @book.cover_image_url('jpg') %>
   <% end %>
 
-  <script type="application/ld+json">
-  <%= raw @book.structured_data.to_json %>
-  </script>
-
   <%= tag 'link', rel: 'modulepreload', href: 'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0.36/dist/fancybox/fancybox.esm.min.js' %>
 <% end %>
 


### PR DESCRIPTION
Google was erroring out on this because a `WorkExample` of `Book` objects can't be books? — Given my conversations with some googlers, they are not using this anyway so I'm removing this from the markup for the time being.