### PR TITLE
Fixing author list in the book admin view

### DIFF
--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -360,7 +360,9 @@ ActiveAdmin.register Book do
                    hint: 'Vinsamlegast hafið samband við skrifstofu FÍBÚT ef '\
                          'hlutverk vantar í fellilista.'
           ba.input :author,
-                   collection: Author.all.map { |a| [a.format_name, a.id] },
+                   collection: Author.order(:name, :birthyear).map { |a|
+                     [a.format_name, a.id]
+                   },
                    label_method: :format_name,
                    hint: 'Hvern og einn höfund, þýðanda, myndhöfund o.s.frv. '\
                          'þarf að skrá í sitt hvoru lagi. Ef höfundur finnst '\


### PR DESCRIPTION
Authors were not appearing in alphabetical order. This has been corrected.