### PR TITLE
Discounting <em> tags from maximum length for book descriptions

### DIFF
--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -411,7 +411,11 @@ ActiveAdmin.register Book do
                   input_html: {
                     rows: 5,
                     autocomplete: 'off',
-                    maxlength: Book::DESCRIPTION_MAX_LENGTH
+                    maxlength: if current_admin_user.admin?
+                                 nil
+                               else
+                                 Book::DESCRIPTION_MAX_LENGTH
+                               end
                   },
                   hint: 'Stuttur kynningartexti sem birtist á yfirlitssíðu '\
                         'vefsins og í prentútgáfu Bókatíðinda. '\

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -93,11 +93,12 @@ class Book < ApplicationRecord
   attribute :delete_sample_pages
 
   validates :publisher, :title, :description, presence: true
-  validates :description, length: { maximum: DESCRIPTION_MAX_LENGTH }
   validates :long_description, length: { maximum: LONG_DESCRIPTION_MAX_LENGTH }
 
   validates :book_authors, length: { minimum: 1 }
   validates :book_binding_types, length: { minimum: 1 }
+
+  validate :validate_description_length
 
   scope :old, lambda {
     includes(
@@ -156,6 +157,17 @@ class Book < ApplicationRecord
       :book_authors
     )
   }
+
+  def validate_description_length
+    return if description_sans_em.length <= DESCRIPTION_MAX_LENGTH
+
+    errors.add(:description,
+               "þarf að vera hámark #{DESCRIPTION_MAX_LENGTH} slög")
+  end
+
+  def description_sans_em
+    ActionController::Base.helpers.strip_tags description
+  end
 
   def self.ransackable_associations(_auth_object = nil)
     reflect_on_all_associations.map { |a| a.name.to_s }


### PR DESCRIPTION
Admin users can now go beyond 350 characters when entering the short book description into the form. HTML tags are stipped from the textual content when validating the lenght.