### PR TITLE
Adding support for book tags

### DIFF
--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -24,6 +24,9 @@ ActiveAdmin.register Book do
                   blockquotes_attributes: %i[
                     id quote_type location heading quote citation _destroy
                   ],
+                  book_tags_attributes: %i[
+                    id tag_id
+                  ],
                   edition_ids: [],
                   sample_pages_files: []
                 }
@@ -655,6 +658,9 @@ ActiveAdmin.register Book do
 
       tab I18n.t('active_admin.tabs.book.bibliography') do
         f.inputs 'Nánari upplýsingar' do
+          f.has_many :book_tags, heading: 'Efnisorð bókar' do |book_tag|
+            book_tag.input :tag, collection: Tag.where(active: true)
+          end
           f.input :original_title, hint: 'Upprunalegur titill bókar ef erlend.'
           f.input(
             :country_of_origin,

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Tag do
+  config.sort_order = 'rod_asc'
+  permit_params :title, :title_plural, :slug, :description, :active, :rod
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -63,6 +63,9 @@ class Book < ApplicationRecord
 
   has_many :blockquotes, dependent: :destroy, inverse_of: :book
 
+  has_many :book_tags, dependent: :destroy, inverse_of: :book
+  has_many :tags, through: :book_tags
+
   # This prevents the deletion of books that have been assigned bo editions.
   has_many :book_editions, dependent: :restrict_with_error
   has_many :editions, through: :book_editions
@@ -73,6 +76,7 @@ class Book < ApplicationRecord
   accepts_nested_attributes_for :book_categories, allow_destroy: true
   accepts_nested_attributes_for :book_binding_types, allow_destroy: true
   accepts_nested_attributes_for :blockquotes, allow_destroy: true
+  accepts_nested_attributes_for :book_tags, allow_destroy: true
 
   has_one_attached :cover_image, dependent: :destroy
   has_one_attached :audio_sample, dependent: :destroy

--- a/app/models/book_tag.rb
+++ b/app/models/book_tag.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class BookTag < ApplicationRecord
+  belongs_to :book
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Tag < ApplicationRecord
+  def self.ransackable_attributes(_auth_object = nil)
+    ['title', 'title_plural', 'slug', 'description', 'active', 'rod']
+  end
+end

--- a/app/views/books/_meta.erb
+++ b/app/views/books/_meta.erb
@@ -3,6 +3,17 @@
   class="book-meta-list d-block pl-0 mt-0 t-md-3"
 >
 
+  <li
+    class="book-meta-tags d-block pb-3"
+    aria-label="Efnisorð"
+  >
+    <ul class="d-block p-0">
+      <% local_assigns[:book].tags.order(rod: :asc).each do |t| %>
+      <li id="book-tag-<%= t.slug %>" class="badge badge-primary"><%= t.title %></li>
+      <% end %>
+    </ul>
+  </li>
+
   <% if action_name == 'show' %>
   <li
     class="book-meta-publisher d-block pb-3"

--- a/app/views/books/_meta_mobile.erb
+++ b/app/views/books/_meta_mobile.erb
@@ -3,6 +3,17 @@
   class="book-meta-list d-block pl-0 mt-0 t-md-3"
 >
 
+  <li
+    class="book-meta-tags d-block pb-3"
+    aria-label="Efnisorð"
+  >
+    <ul class="d-block p-0">
+      <% local_assigns[:book].tags.order(rod: :asc).each do |t| %>
+      <li id="book-tag-<%= t.slug %>" class="badge badge-primary"><%= t.title %></li>
+      <% end %>
+    </ul>
+  </li>
+
   <% if action_name == 'show' %>
   <li
     class="book-meta-publisher d-block pb-3"

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -55,6 +55,12 @@ is:
     :create: 'Ganga frá skráningu'
     :update: 'Uppfæra'
     :required: 'þarf að fylla út'
+  ransack:
+    predicates:
+      cont: 'Inniheldur'
+      eq: 'Jafngildir'
+      start: 'Byrjar á'
+      end: 'Endar á'
   activerecord:
     errors:
       models:
@@ -118,6 +124,9 @@ is:
             book_binding_types:
               too_short: 'þurfa að vera skilgreind'
     models:
+      tag:
+        one: 'efnisorð'
+        other: 'efnisorð'
       page:
         one: 'síða'
         other: 'síður'
@@ -154,6 +163,13 @@ is:
         one: 'flokkur'
         other: 'flokkar'
     attributes:
+      tag:
+        title: 'Nafn'
+        title_plural: 'Nafn í fleirtölu'
+        slug: 'Tilvísun'
+        description: 'Lýsing'
+        active: 'Virkt'
+        rod: 'Röðun'
       page:
         title: 'Titill'
         body: 'Meginmál'

--- a/db/migrate/20260421190621_create_tags.rb
+++ b/db/migrate/20260421190621_create_tags.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateTags < ActiveRecord::Migration[8.1]
+  def up
+    create_table :tags do |t|
+      t.string :title, null: false
+      t.string :title_plural, null: false
+      t.string :slug, null: false
+      t.string :description, default: '', null: false
+      t.boolean :active, default: true, null: false
+      t.integer :rod, default: 0, null: false
+      t.timestamps
+      t.index :title
+    end
+  end
+
+  def down
+    drop_table :tags
+  end
+end

--- a/db/migrate/20260421191300_create_book_tags.rb
+++ b/db/migrate/20260421191300_create_book_tags.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateBookTags < ActiveRecord::Migration[8.1]
+  def up
+    create_table :book_tags do |t|
+      t.integer :book_id, null: false
+      t.integer :tag_id, null: false
+      t.timestamps
+    end
+    add_foreign_key :book_tags, :books
+    add_foreign_key :book_tags, :tags
+  end
+
+  def down
+    drop_table :book_tags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_191300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
 
   create_table "active_admin_comments", force: :cascade do |t|
-    t.string "namespace"
-    t.text "body"
-    t.string "resource_type"
-    t.bigint "resource_id"
-    t.string "author_type"
     t.bigint "author_id"
+    t.string "author_type"
+    t.text "body"
     t.datetime "created_at", null: false
+    t.string "namespace"
+    t.bigint "resource_id"
+    t.string "resource_type"
     t.datetime "updated_at", null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
@@ -30,24 +30,24 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", precision: nil, null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -59,30 +59,30 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
 
   create_table "admin_user_publishers", force: :cascade do |t|
     t.integer "admin_user_id"
-    t.integer "publisher_id"
     t.datetime "created_at", null: false
+    t.integer "publisher_id"
     t.datetime "updated_at", null: false
     t.index ["admin_user_id"], name: "index_admin_user_publishers_on_admin_user_id"
     t.index ["publisher_id"], name: "index_admin_user_publishers_on_publisher_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
-    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "current_sign_in_at"
+    t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
-    t.string "unlock_token"
+    t.datetime "last_sign_in_at"
+    t.string "last_sign_in_ip"
     t.datetime "locked_at"
+    t.string "name"
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
     t.integer "role", default: 0
-    t.datetime "created_at", null: false
+    t.integer "sign_in_count", default: 0, null: false
+    t.string "unlock_token"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
@@ -90,32 +90,32 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "author_types", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "name"
-    t.string "slug"
-    t.integer "rod"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "abbreviation"
+    t.datetime "created_at", null: false
+    t.string "name"
     t.string "plural_name"
+    t.integer "rod"
     t.integer "schema_role", default: 0
+    t.string "slug"
+    t.integer "source_id"
+    t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_author_types_on_slug", unique: true
     t.index ["source_id"], name: "index_author_types_on_source_id", unique: true
   end
 
   create_table "authors", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "firstname"
-    t.string "lastname"
-    t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "is_icelandic"
-    t.string "order_by_name"
-    t.string "name"
     t.integer "added_by_id"
-    t.integer "schema_type", default: 0, null: false
     t.integer "birthyear"
+    t.datetime "created_at", null: false
+    t.string "firstname"
+    t.boolean "is_icelandic"
+    t.string "lastname"
+    t.string "name"
+    t.string "order_by_name"
+    t.integer "schema_type", default: 0, null: false
+    t.string "slug"
+    t.integer "source_id"
+    t.datetime "updated_at", null: false
     t.index ["is_icelandic"], name: "index_authors_on_is_icelandic"
     t.index ["order_by_name"], name: "index_authors_on_order_by_name"
     t.index ["slug"], name: "index_authors_on_slug", unique: true
@@ -123,39 +123,39 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "binding_types", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "name"
-    t.string "slug"
-    t.integer "rod"
-    t.boolean "open"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "group", default: 0, null: false
     t.integer "barcode_type", default: 0
+    t.datetime "created_at", null: false
+    t.integer "group", default: 0, null: false
+    t.string "name"
+    t.boolean "open"
+    t.integer "rod"
+    t.string "slug"
+    t.integer "source_id"
+    t.datetime "updated_at", null: false
     t.index ["name"], name: "index_binding_types_on_name", unique: true
     t.index ["slug"], name: "index_binding_types_on_slug", unique: true
     t.index ["source_id"], name: "index_binding_types_on_source_id", unique: true
   end
 
   create_table "blockquotes", force: :cascade do |t|
-    t.string "quote", limit: 512
-    t.string "citation", limit: 63
-    t.integer "location", default: 0
-    t.integer "size", default: 0
     t.bigint "book_id"
+    t.string "citation", limit: 63
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "heading", limit: 128
+    t.integer "location", default: 0
+    t.string "quote", limit: 512
     t.integer "quote_type", default: 0
+    t.integer "size", default: 0
+    t.datetime "updated_at", null: false
     t.index ["book_id"], name: "index_blockquotes_on_book_id"
   end
 
   create_table "book_authors", force: :cascade do |t|
-    t.integer "source_id"
-    t.bigint "book_id"
     t.bigint "author_id"
     t.bigint "author_type_id"
+    t.bigint "book_id"
     t.datetime "created_at", null: false
+    t.integer "source_id"
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_book_authors_on_author_id"
     t.index ["author_type_id"], name: "index_book_authors_on_author_type_id"
@@ -164,17 +164,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "book_binding_types", force: :cascade do |t|
-    t.string "barcode"
-    t.bigint "book_id"
-    t.bigint "binding_type_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "language", limit: 2, default: "is", null: false
-    t.string "url"
-    t.integer "page_count"
-    t.integer "minutes"
     t.integer "availability", default: 0, null: false
+    t.string "barcode"
+    t.bigint "binding_type_id"
+    t.bigint "book_id"
+    t.datetime "created_at", null: false
+    t.string "language", limit: 2, default: "is", null: false
+    t.integer "minutes"
+    t.integer "page_count"
     t.date "publication_date"
+    t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["barcode"], name: "index_book_binding_types_on_barcode"
     t.index ["binding_type_id"], name: "index_book_binding_types_on_binding_type_id"
     t.index ["book_id"], name: "index_book_binding_types_on_book_id"
@@ -185,9 +185,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
     t.bigint "book_id"
     t.bigint "category_id"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "for_print", default: true, null: false
     t.boolean "for_web", default: true, null: false
+    t.datetime "updated_at", null: false
     t.index ["book_id"], name: "index_book_categories_on_book_id"
     t.index ["category_id"], name: "index_book_categories_on_category_id"
     t.index ["for_print"], name: "index_book_categories_on_for_print"
@@ -197,45 +197,52 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   create_table "book_edition_categories", force: :cascade do |t|
     t.integer "book_edition_id"
     t.integer "category_id"
-    t.boolean "for_web", default: true, null: false
-    t.boolean "for_print", default: true, null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "invoiced", default: false
     t.string "dk_invoice_number"
+    t.boolean "for_print", default: true, null: false
+    t.boolean "for_web", default: true, null: false
+    t.boolean "invoiced", default: false
+    t.datetime "updated_at", null: false
     t.index ["invoiced"], name: "index_book_edition_categories_on_invoiced"
   end
 
   create_table "book_editions", force: :cascade do |t|
     t.bigint "book_id"
-    t.bigint "edition_id"
     t.datetime "created_at", null: false
+    t.bigint "edition_id"
     t.datetime "updated_at", null: false
     t.index ["book_id"], name: "index_book_editions_on_book_id"
     t.index ["edition_id"], name: "index_book_editions_on_edition_id"
   end
 
+  create_table "book_tags", force: :cascade do |t|
+    t.integer "book_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "tag_id", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "books", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "pre_title"
-    t.string "title"
-    t.string "post_title"
-    t.string "slug"
+    t.string "country_of_origin"
+    t.json "cover_image_srcsets"
+    t.datetime "created_at", null: false
     t.string "description"
     t.string "long_description"
+    t.string "original_language", limit: 2
+    t.string "original_title"
+    t.string "post_title"
+    t.string "pre_title"
     t.bigint "publisher_id"
-    t.datetime "created_at", null: false
+    t.json "sample_pages_srcsets"
+    t.string "slug"
+    t.integer "source_id"
+    t.string "title"
+    t.string "title_hypenated"
+    t.string "title_noshy"
     t.datetime "updated_at", null: false
+    t.string "uri_to_audiobook"
     t.string "uri_to_buy"
     t.string "uri_to_sample"
-    t.string "uri_to_audiobook"
-    t.string "title_noshy"
-    t.string "title_hypenated"
-    t.string "country_of_origin"
-    t.string "original_title"
-    t.json "cover_image_srcsets"
-    t.json "sample_pages_srcsets"
-    t.string "original_language", limit: 2
     t.index ["country_of_origin"], name: "index_books_on_country_of_origin"
     t.index ["publisher_id"], name: "index_books_on_publisher_id"
     t.index ["slug"], name: "index_books_on_slug", unique: true
@@ -243,18 +250,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "categories", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "origin_name"
-    t.string "slug"
-    t.integer "rod"
+    t.integer "book_count"
+    t.integer "book_count_print"
+    t.integer "book_count_web"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "description", limit: 160, default: ""
     t.integer "group"
     t.string "name"
-    t.integer "book_count"
-    t.integer "book_count_web"
-    t.integer "book_count_print"
-    t.string "description", limit: 160, default: ""
+    t.string "origin_name"
+    t.integer "rod"
+    t.string "slug"
+    t.integer "source_id"
+    t.datetime "updated_at", null: false
     t.index ["group"], name: "index_categories_on_group"
     t.index ["rod"], name: "index_categories_on_rod"
     t.index ["slug"], name: "index_categories_on_slug", unique: true
@@ -262,20 +269,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "editions", force: :cascade do |t|
-    t.string "title"
-    t.string "original_title_id_string"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "print_date"
     t.datetime "closing_date"
-    t.datetime "opening_date"
-    t.datetime "online_date"
     t.json "cover_image_srcsets", default: {"webp" => "", "jpg" => ""}
+    t.datetime "created_at", null: false
     t.boolean "is_legacy"
-    t.integer "year"
     t.boolean "online", default: false
-    t.boolean "open_to_web_registrations", default: false
+    t.datetime "online_date"
     t.boolean "open_to_print_registrations", default: false
+    t.boolean "open_to_web_registrations", default: false
+    t.datetime "opening_date"
+    t.string "original_title_id_string"
+    t.datetime "print_date"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.integer "year"
     t.index ["closing_date"], name: "index_editions_on_closing_date"
     t.index ["online"], name: "index_editions_on_online"
     t.index ["online_date"], name: "index_editions_on_online_date"
@@ -286,78 +293,78 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "description"
-    t.jsonb "serialized_properties"
-    t.text "on_finish"
-    t.text "on_success"
-    t.text "on_discard"
-    t.text "callback_queue_name"
     t.integer "callback_priority"
-    t.datetime "enqueued_at"
+    t.text "callback_queue_name"
+    t.datetime "created_at", null: false
+    t.text "description"
     t.datetime "discarded_at"
+    t.datetime "enqueued_at"
     t.datetime "finished_at"
     t.datetime "jobs_finished_at"
+    t.text "on_discard"
+    t.text "on_finish"
+    t.text "on_success"
+    t.jsonb "serialized_properties"
+    t.datetime "updated_at", null: false
   end
 
   create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "active_job_id", null: false
-    t.text "job_class"
-    t.text "queue_name"
-    t.jsonb "serialized_params"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
-    t.text "error"
-    t.integer "error_event", limit: 2
-    t.text "error_backtrace", array: true
-    t.uuid "process_id"
+    t.datetime "created_at", null: false
     t.interval "duration"
+    t.text "error"
+    t.text "error_backtrace", array: true
+    t.integer "error_event", limit: 2
+    t.datetime "finished_at"
+    t.text "job_class"
+    t.uuid "process_id"
+    t.text "queue_name"
+    t.datetime "scheduled_at"
+    t.jsonb "serialized_params"
+    t.datetime "updated_at", null: false
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
     t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "state"
     t.integer "lock_type", limit: 2
+    t.jsonb "state"
+    t.datetime "updated_at", null: false
   end
 
   create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.text "key"
+    t.datetime "updated_at", null: false
     t.jsonb "value"
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
   create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "queue_name"
-    t.integer "priority"
-    t.jsonb "serialized_params"
-    t.datetime "scheduled_at"
-    t.datetime "performed_at"
-    t.datetime "finished_at"
-    t.text "error"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "active_job_id"
-    t.text "concurrency_key"
-    t.text "cron_key"
-    t.uuid "retried_good_job_id"
-    t.datetime "cron_at"
-    t.uuid "batch_id"
     t.uuid "batch_callback_id"
-    t.boolean "is_discrete"
-    t.integer "executions_count"
-    t.text "job_class"
+    t.uuid "batch_id"
+    t.text "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "cron_at"
+    t.text "cron_key"
+    t.text "error"
     t.integer "error_event", limit: 2
+    t.integer "executions_count"
+    t.datetime "finished_at"
+    t.boolean "is_discrete"
+    t.text "job_class"
     t.text "labels", array: true
-    t.uuid "locked_by_id"
     t.datetime "locked_at"
+    t.uuid "locked_by_id"
+    t.datetime "performed_at"
+    t.integer "priority"
+    t.text "queue_name"
+    t.uuid "retried_good_job_id"
+    t.datetime "scheduled_at"
+    t.jsonb "serialized_params"
+    t.datetime "updated_at", null: false
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
@@ -376,36 +383,59 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   end
 
   create_table "pages", force: :cascade do |t|
-    t.string "title"
     t.text "body"
-    t.string "slug"
     t.datetime "created_at", null: false
+    t.string "slug"
+    t.string "title"
     t.datetime "updated_at", null: false
   end
 
   create_table "pg_search_documents", force: :cascade do |t|
     t.text "content"
-    t.string "searchable_type"
-    t.bigint "searchable_id"
     t.datetime "created_at", null: false
+    t.bigint "searchable_id"
+    t.string "searchable_type"
     t.datetime "updated_at", null: false
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
-  create_table "publishers", force: :cascade do |t|
-    t.integer "source_id"
-    t.string "name"
-    t.string "slug"
-    t.string "url"
+  create_table "print_locations", force: :cascade do |t|
+    t.string "address"
     t.datetime "created_at", null: false
+    t.float "latitude"
+    t.float "longitude"
+    t.string "name"
+    t.integer "region", default: 1, null: false
     t.datetime "updated_at", null: false
+    t.boolean "visible", default: true
+  end
+
+  create_table "publishers", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.string "email_address"
-    t.string "kennitala"
     t.boolean "is_member", default: true
+    t.string "kennitala"
+    t.string "name"
     t.integer "schema_type", default: 1, null: false
+    t.string "slug"
+    t.integer "source_id"
+    t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["kennitala"], name: "index_publishers_on_kennitala"
     t.index ["slug"], name: "index_publishers_on_slug", unique: true
     t.index ["source_id"], name: "index_publishers_on_source_id", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "description", default: "", null: false
+    t.integer "rod", default: 0, null: false
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.string "title_plural", null: false
+    t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_tags_on_title"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -421,5 +451,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_173244) do
   add_foreign_key "book_categories", "categories"
   add_foreign_key "book_editions", "books"
   add_foreign_key "book_editions", "editions"
+  add_foreign_key "book_tags", "books"
+  add_foreign_key "book_tags", "tags"
   add_foreign_key "books", "publishers"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :book_tag do
+  end
+
+  factory :tag do
+  end
+
   factory :blockquote do
   end
 

--- a/spec/models/book_tag_spec.rb
+++ b/spec/models/book_tag_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BookTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Tags are used to indicate a sub-category that can't fit into the current gategory system. Examples: Crime novels, Games, Fantasy, Science Fiction etc.